### PR TITLE
Update kkbox.py

### DIFF
--- a/rsack/kkbox.py
+++ b/rsack/kkbox.py
@@ -17,7 +17,9 @@ class Download():
                             region_bypass=True)
         if url.split("/")[-2] == "artist":
             artist = self.client.get_artist(self.id)
-            for album in artist['album']:
+            artist_raw_id = artist["profile"]["artist_id"]
+            artist_albums = self.client.get_artist_albums(artist_raw_id,20,0)
+            for album in artist_albums:
                 self._download_album(album['encrypted_album_id'])
         else:
             self._download_album(self.id)
@@ -93,6 +95,7 @@ class Download():
     def _download_album(self, id):
         self.meta = self.client.get_album(id=id)
         self.meta['release_date'] = self.client.get_date(id)
+        logger.info("Album Name: " + self.meta['album']['album_name'])
         song_list = self.client.get_album_more(self.meta['album']['album_id'])
         self._create_album_folder()
         self._download_cover()

--- a/rsack/kkbox.py
+++ b/rsack/kkbox.py
@@ -13,8 +13,7 @@ class Download():
         self.settings = Settings().KKBox()
         self.id = url.split("/")[-1]
         self.client.login(email=self.settings['email'],
-                            password=self.settings['password'],
-                            region_bypass=True)
+                            password=self.settings['password'])
         if url.split("/")[-2] == "artist":
             artist = self.client.get_artist(self.id)
             artist_raw_id = artist["profile"]["artist_id"]


### PR DESCRIPTION
I try to download all albums of an artist, but only the albums shown in https://play.kkbox.com/artist/XXXXXXXXXXXXXX will be downloaded. 
<details>

![image](https://user-images.githubusercontent.com/57177286/211818532-c445743c-9282-40a0-a433-ac841868aada.png)

</details>


But this is only a part of this artist's albums, not all of this artist's albums. his all albums are showcased at https://play.kkbox.com/artist/xxxxxxxxxxxxxx/albums. and should use “get_artist_albums” function to download from here
<details>

![image](https://user-images.githubusercontent.com/57177286/211819694-52362a4d-e68c-4f8f-9f04-ac1823fc460a.png)

![image](https://user-images.githubusercontent.com/57177286/211819000-4e41a034-9f8f-4ccf-b014-739b706bd1de.png)

</details>


In addition, you seem to use the 'get_date' function in ' rsack\clients\kkbox.py ' to capture the release time of the album through ' Beautifulsoup'. Actually, the release time of the album can also be obtained from 'get_artist_albums'
I feel that it is only suitable for batch downloading all albums of an artist. If only one album is downloaded, the current method is more convenient

(I have the log print out the name of the album currently being downloaded, so it looks a little clearer)

hope there is nothing wrong